### PR TITLE
feat: freeze BluetoothServiceInfo dataclass

### DIFF
--- a/src/home_assistant_bluetooth/models.py
+++ b/src/home_assistant_bluetooth/models.py
@@ -16,12 +16,12 @@ if TYPE_CHECKING:
     )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class BaseServiceInfo:
     """Base class for discovery ServiceInfo."""
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class BluetoothServiceInfo(BaseServiceInfo):
     """Prepared info from bluetooth entries."""
 


### PR DESCRIPTION
To be able to freeze the dataclasses that are using these as base classes, these classes must be frozen.

This data should never change once its created.