### PR TITLE
fix: revert freeze BluetoothServiceInfo dataclass

### DIFF
--- a/src/home_assistant_bluetooth/models.py
+++ b/src/home_assistant_bluetooth/models.py
@@ -16,12 +16,12 @@ if TYPE_CHECKING:
     )
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class BaseServiceInfo:
     """Base class for discovery ServiceInfo."""
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class BluetoothServiceInfo(BaseServiceInfo):
     """Prepared info from bluetooth entries."""
 


### PR DESCRIPTION
There are some libs that are failing with this change and since they are not hard pinned we need to revert this for now and come back to it later.

Revert "feat: freeze BluetoothServiceInfo dataclass"

This reverts commit bc61444acde3cfb0b6c926072cf7c40f5a6ca744.