### PR TITLE
feat: move BluetoothServiceInfoBleak out of the bluetooth integration

### DIFF
--- a/src/home_assistant_bluetooth/__init__.py
+++ b/src/home_assistant_bluetooth/__init__.py
@@ -1,5 +1,15 @@
 __version__ = "1.6.0"
 
-from .models import SOURCE_LOCAL, BaseServiceInfo, BluetoothServiceInfo
+from .models import (
+    SOURCE_LOCAL,
+    BaseServiceInfo,
+    BluetoothServiceInfo,
+    BluetoothServiceInfoBleak,
+)
 
-__all__ = ["BaseServiceInfo", "BluetoothServiceInfo", "SOURCE_LOCAL"]
+__all__ = [
+    "BaseServiceInfo",
+    "BluetoothServiceInfo",
+    "BluetoothServiceInfoBleak",
+    "SOURCE_LOCAL",
+]

--- a/src/home_assistant_bluetooth/models.py
+++ b/src/home_assistant_bluetooth/models.py
@@ -3,17 +3,15 @@ from __future__ import annotations
 
 import dataclasses
 from functools import cached_property
-from typing import TYPE_CHECKING, Final, TypeVar
+from typing import Any, Final, TypeVar
 
+from bleak.backends.device import BLEDevice
+from bleak.backends.scanner import AdvertisementData
+
+_BluetoothServiceInfoSelfT = TypeVar(
+    "_BluetoothServiceInfoSelfT", bound="BluetoothServiceInfo"
+)
 SOURCE_LOCAL: Final = "local"
-
-if TYPE_CHECKING:
-    from bleak.backends.device import BLEDevice
-    from bleak.backends.scanner import AdvertisementData
-
-    _BluetoothServiceInfoSelfT = TypeVar(
-        "_BluetoothServiceInfoSelfT", bound="BluetoothServiceInfo"
-    )
 
 
 @dataclasses.dataclass
@@ -70,3 +68,63 @@ class BluetoothServiceInfo(BaseServiceInfo):
         for manufacturer in self.manufacturer_data:
             return manufacturer
         return None
+
+
+@dataclasses.dataclass
+class BluetoothServiceInfoBleak(BluetoothServiceInfo):
+    """BluetoothServiceInfo with bleak data.
+
+    Integrations may need BLEDevice and AdvertisementData
+    to connect to the device without having bleak trigger
+    another scan to translate the address to the system's
+    internal details.
+    """
+
+    device: BLEDevice
+    advertisement: AdvertisementData
+    connectable: bool
+    time: float
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return as dict.
+
+        The dataclass asdict method is not used because
+        it will try to deepcopy pyobjc data which will fail.
+        """
+        return {
+            "name": self.name,
+            "address": self.address,
+            "rssi": self.rssi,
+            "manufacturer_data": self.manufacturer_data,
+            "service_data": self.service_data,
+            "service_uuids": self.service_uuids,
+            "source": self.source,
+            "advertisement": self.advertisement,
+            "device": self.device,
+            "connectable": self.connectable,
+            "time": self.time,
+        }
+
+    @classmethod
+    def from_scan(
+        cls: BluetoothServiceInfoBleak,
+        source: str,
+        device: BLEDevice,
+        advertisement_data: AdvertisementData,
+        monotonic_time: float,
+        connectable: bool,
+    ) -> BluetoothServiceInfoBleak:
+        """Create a BluetoothServiceInfoBleak from a scanner."""
+        return cls(
+            name=advertisement_data.local_name or device.name or device.address,
+            address=device.address,
+            rssi=advertisement_data.rssi,
+            manufacturer_data=advertisement_data.manufacturer_data,
+            service_data=advertisement_data.service_data,
+            service_uuids=advertisement_data.service_uuids,
+            source=source,
+            device=device,
+            advertisement=advertisement_data,
+            connectable=connectable,
+            time=monotonic_time,
+        )

--- a/src/home_assistant_bluetooth/models.py
+++ b/src/home_assistant_bluetooth/models.py
@@ -11,6 +11,10 @@ from bleak.backends.scanner import AdvertisementData
 _BluetoothServiceInfoSelfT = TypeVar(
     "_BluetoothServiceInfoSelfT", bound="BluetoothServiceInfo"
 )
+
+_BluetoothServiceInfoBleakSelfT = TypeVar(
+    "_BluetoothServiceInfoBleakSelfT", bound="BluetoothServiceInfoBleak"
+)
 SOURCE_LOCAL: Final = "local"
 
 
@@ -107,13 +111,13 @@ class BluetoothServiceInfoBleak(BluetoothServiceInfo):
 
     @classmethod
     def from_scan(
-        cls: BluetoothServiceInfoBleak,
+        cls: type[_BluetoothServiceInfoBleakSelfT],
         source: str,
         device: BLEDevice,
         advertisement_data: AdvertisementData,
         monotonic_time: float,
         connectable: bool,
-    ) -> BluetoothServiceInfoBleak:
+    ) -> _BluetoothServiceInfoBleakSelfT:
         """Create a BluetoothServiceInfoBleak from a scanner."""
         return cls(
             name=advertisement_data.local_name or device.name or device.address,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,12 @@
+import time
+
 from bleak.backends.device import BLEDevice
 
-from home_assistant_bluetooth import SOURCE_LOCAL, BluetoothServiceInfo
+from home_assistant_bluetooth import (
+    SOURCE_LOCAL,
+    BluetoothServiceInfo,
+    BluetoothServiceInfoBleak,
+)
 
 from . import generate_advertisement_data
 
@@ -47,3 +53,37 @@ def test_model_from_bleak():
     assert service_info.source == SOURCE_LOCAL
     assert service_info.manufacturer is None
     assert service_info.manufacturer_id is None
+
+
+def test_model_from_scanner():
+    switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
+    switchbot_adv = generate_advertisement_data(
+        local_name="wohand", service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
+    )
+    now = time.monotonic()
+    service_info = BluetoothServiceInfoBleak.from_scan(
+        SOURCE_LOCAL, switchbot_device, switchbot_adv, now, True
+    )
+
+    assert service_info.service_uuids == ["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
+    assert service_info.name == "wohand"
+    assert service_info.source == SOURCE_LOCAL
+    assert service_info.manufacturer is None
+    assert service_info.manufacturer_id is None
+    assert service_info.time == now
+    assert service_info.connectable is True
+
+    safe_as_dict = service_info.as_dict()
+    assert safe_as_dict == {
+        "address": "44:44:33:11:23:45",
+        "advertisement": switchbot_adv,
+        "device": switchbot_device,
+        "connectable": True,
+        "manufacturer_data": {},
+        "name": "wohand",
+        "rssi": -127,
+        "service_data": {},
+        "service_uuids": ["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
+        "source": "local",
+        "time": now,
+    }


### PR DESCRIPTION
- Since many integrations need the AdvertisementData and BLEDevice objects, moving the object into the lib makes avoids having to translate it at the integraton point and makes the typing a bit easier