### PR TITLE
fix: make MANUFACTURERS import late

### DIFF
--- a/src/home_assistant_bluetooth/models.py
+++ b/src/home_assistant_bluetooth/models.py
@@ -2,8 +2,6 @@
 
 from typing import TYPE_CHECKING, Any, Dict, Final, List, Optional, Type, TypeVar
 
-from bleak.backends._manufacturers import MANUFACTURERS
-
 if TYPE_CHECKING:
     from bleak.backends.device import BLEDevice
     from bleak.backends.scanner import AdvertisementData
@@ -75,6 +73,10 @@ class BluetoothServiceInfo(BaseServiceInfo):
     @property
     def manufacturer(self) -> Optional[str]:
         """Convert manufacturer data to a string."""
+        from bleak.backends._manufacturers import (
+            MANUFACTURERS,  # pylint: disable=import-outside-toplevel
+        )
+
         for manufacturer in self.manufacturer_data:
             if manufacturer in MANUFACTURERS:
                 name: str = MANUFACTURERS[manufacturer]


### PR DESCRIPTION
This is only ever called if we already have bleak installed

https://github.com/home-assistant-libs/home-assistant-bluetooth/pull/16#discussion_r1061627294