### PR TITLE
fix: bump python-semantic-release to fix release process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,14 +82,14 @@ jobs:
 
       # Do a dry run of PSR
       - name: Test release
-        uses: python-semantic-release/python-semantic-release@v8.5.1
+        uses: python-semantic-release/python-semantic-release@v8.7.2
         if: github.ref_name != 'main'
         with:
           root_options: --noop
 
       # On main branch: actual PSR + upload to PyPI & GitHub
       - name: Release
-        uses: python-semantic-release/python-semantic-release@v8.5.1
+        uses: python-semantic-release/python-semantic-release@v8.7.2
         id: release
         if: github.ref_name == 'main'
         with:


### PR DESCRIPTION
looks like I didn't go high enough in https://github.com/home-assistant-libs/home-assistant-bluetooth/pull/32 since the process still failed

not obvious if this is the issue but I'm trying the safe fix first
