### PR TITLE
fix: python version in release upload workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: test_release
     concurrency: release
+    if: github.ref_name != 'main'
 
     steps:
       - uses: actions/checkout@v4
@@ -85,7 +86,6 @@ jobs:
       # Dry run of PSR to build the distribution
       - name: Test release
         uses: python-semantic-release/python-semantic-release@v8.7.2
-        if: github.ref_name != 'main'
         with:
           root_options: --noop
 
@@ -129,6 +129,11 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref || github.ref_name }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
 
       # On main branch: Call PSR to build the distribution
       - name: Release


### PR DESCRIPTION
We need to use a python version new enough for the project or it fails to build