### PR TITLE
chore: switch back to python-semantic-release/python-semantic-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
 
       # On main branch: Call PSR to build the distribution
       - name: Release
-        uses: bluetooth-devices/python-semantic-release@311
+        uses: python-semantic-release/python-semantic-release@v10.2.0
         id: release
 
         with:


### PR DESCRIPTION
We had a fork here because we needed a newer minimum Python version that python-semantic-release/python-semantic-release did not support