### PR TITLE
ci: scope release env and OIDC permissions to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,7 @@ jobs:
     needs:
       - build_release
 
+    if: github.ref_name == 'main'
     runs-on: ubuntu-latest
     environment: release
     concurrency: release


### PR DESCRIPTION
## Summary

The release job held id-token: write, contents: write, and the release environment but carried no job level guard, so on paper those release credentials were declared for every trigger including pull requests even though publishing only happens on main; this scopes the release environment plus write and OIDC permissions to a job level main guard so they never apply to untrusted PR code.

## Details

The dry run path already lives in test_release, which runs on PRs and non-main pushes with the test_release environment and no OIDC, just the python-semantic-release dry run. This change adds if: github.ref_name == 'main' to the privileged release job so the release environment and the id-token: write and contents: write permissions are gated at the job level rather than relying only on the upstream needs chain.

## Test plan

- [ ] workflow YAML parses clean
- [ ] dry-run path runs on this PR, publish job stays skipped
